### PR TITLE
fix hydration mismatch on textarea

### DIFF
--- a/ui/components/Chat.tsx
+++ b/ui/components/Chat.tsx
@@ -126,6 +126,7 @@ export function Chat({ messages, onSendMessage, isLoading }: ChatProps) {
                     onKeyDown={handleKeyDown}
                     onCompositionStart={() => setIsComposing(true)}
                     onCompositionEnd={() => setIsComposing(false)}
+                    suppressHydrationWarning
                   />
                 </div>
                 <button


### PR DESCRIPTION
## Summary
- suppress hydration warning on chat textarea to avoid mismatched server/client attributes

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6890a1fa50bc8325b03593278c755622